### PR TITLE
Configure HMR port and host in Vite server setup

### DIFF
--- a/chemlab 1/server/vite.ts
+++ b/chemlab 1/server/vite.ts
@@ -22,7 +22,11 @@ export function log(message: string, source = "express") {
 export async function setupVite(app: Express, server: Server) {
   const serverOptions = {
     middlewareMode: true,
-    hmr: { server },
+    hmr: {
+      server,
+      port: 5000,
+      host: "localhost",
+    },
     allowedHosts: true,
   };
 


### PR DESCRIPTION
Expands the HMR configuration in the Vite server setup to include explicit port and host settings.

Changes:
- Set HMR port to 5000
- Set HMR host to "localhost"
- Reformatted HMR object to multiline for better readability

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/af3161ce16124a50a5ac41f7c376e744/zenith-garden)

👀 [Preview Link](https://af3161ce16124a50a5ac41f7c376e744-zenith-garden.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>af3161ce16124a50a5ac41f7c376e744</projectId>-->
<!--<branchName>zenith-garden</branchName>-->